### PR TITLE
Improve SAC training with adaptive entropy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+path = "lib.rs"
 
 [dependencies]
 wasm-bindgen = "0.2.87"


### PR DESCRIPTION
## Summary
- tune SAC hyperparameters and introduce automatic entropy coefficient adjustment
- return alpha diagnostics and send them in worker messages
- fix Cargo manifest so `cargo check` can run

## Testing
- `node --check worker.js`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68527a1cf510832f94f78251125cd044