### PR TITLE
Update JS bindings; remove wasm diff

### DIFF
--- a/pkg_physics/physics_engine.d.ts
+++ b/pkg_physics/physics_engine.d.ts
@@ -1,40 +1,37 @@
-declare namespace wasm_bindgen {
-	/* tslint:disable */
-	/* eslint-disable */
-	export class PhysicsParams {
-	  private constructor();
-	  free(): void;
-	  cart_m: number;
-	  m1: number;
-	  m2: number;
-	  l1_m: number;
-	  l2_m: number;
-	  g: number;
-	}
-	export class PhysicsState {
-	  private constructor();
-	  free(): void;
-	  a1: number;
-	  a2: number;
-	  a1_v: number;
-	  a2_v: number;
-	  cart_x_m: number;
-	  cart_x_v_m: number;
-	}
-	export class WasmPendulumPhysics {
-	  free(): void;
-	  constructor(cart_m: number, m1: number, m2: number, l1_m: number, l2_m: number, g: number);
-	  reset(): void;
-	  get_state_js(): any;
-	  get_params_js(): any;
-	  update_physics_step(dt: number, force_override: number, simulation_mode_is_observing: boolean): boolean;
-	}
-	
+/* tslint:disable */
+/* eslint-disable */
+export class PhysicsParams {
+  private constructor();
+  free(): void;
+  cart_m: number;
+  m1: number;
+  m2: number;
+  l1_m: number;
+  l2_m: number;
+  g: number;
+}
+export class PhysicsState {
+  private constructor();
+  free(): void;
+  a1: number;
+  a2: number;
+  a1_v: number;
+  a2_v: number;
+  cart_x_m: number;
+  cart_x_v_m: number;
+}
+export class WasmPendulumPhysics {
+  free(): void;
+  constructor(cart_m: number, m1: number, m2: number, l1_m: number, l2_m: number, g: number);
+  reset(): void;
+  get_state_js(): any;
+  get_params_js(): any;
+  update_physics_step(dt: number, force_override: number, simulation_mode_is_observing: boolean): boolean;
 }
 
-declare type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
-declare interface InitOutput {
+export interface InitOutput {
   readonly memory: WebAssembly.Memory;
   readonly __wbg_physicsparams_free: (a: number, b: number) => void;
   readonly __wbg_get_physicsparams_cart_m: (a: number) => number;
@@ -72,6 +69,17 @@ declare interface InitOutput {
   readonly __wbindgen_start: () => void;
 }
 
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+/**
+* Instantiates the given `module`, which can either be bytes or
+* a precompiled `WebAssembly.Module`.
+*
+* @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+*
+* @returns {InitOutput}
+*/
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
 /**
 * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
 * for everything else, calls `WebAssembly.instantiate` directly.
@@ -80,4 +88,4 @@ declare interface InitOutput {
 *
 * @returns {Promise<InitOutput>}
 */
-declare function wasm_bindgen (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/pkg_physics/physics_engine.js
+++ b/pkg_physics/physics_engine.js
@@ -1,427 +1,412 @@
-let wasm_bindgen;
-(function() {
-    const __exports = {};
-    let script_src;
-    if (typeof document !== 'undefined' && document.currentScript !== null) {
-        script_src = new URL(document.currentScript.src, location.href).toString();
+let wasm;
+
+const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
+
+if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
     }
-    let wasm = undefined;
+    return cachedUint8ArrayMemory0;
+}
 
-    const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
 
-    if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
+const PhysicsParamsFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_physicsparams_free(ptr >>> 0, 1));
 
-    let cachedUint8ArrayMemory0 = null;
+export class PhysicsParams {
 
-    function getUint8ArrayMemory0() {
-        if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-            cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-        }
-        return cachedUint8ArrayMemory0;
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        PhysicsParamsFinalization.unregister(this);
+        return ptr;
     }
 
-    function getStringFromWasm0(ptr, len) {
-        ptr = ptr >>> 0;
-        return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_physicsparams_free(ptr, 0);
+    }
+    /**
+     * @returns {number}
+     */
+    get cart_m() {
+        const ret = wasm.__wbg_get_physicsparams_cart_m(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set cart_m(arg0) {
+        wasm.__wbg_set_physicsparams_cart_m(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get m1() {
+        const ret = wasm.__wbg_get_physicsparams_m1(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set m1(arg0) {
+        wasm.__wbg_set_physicsparams_m1(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get m2() {
+        const ret = wasm.__wbg_get_physicsparams_m2(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set m2(arg0) {
+        wasm.__wbg_set_physicsparams_m2(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get l1_m() {
+        const ret = wasm.__wbg_get_physicsparams_l1_m(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set l1_m(arg0) {
+        wasm.__wbg_set_physicsparams_l1_m(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get l2_m() {
+        const ret = wasm.__wbg_get_physicsparams_l2_m(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set l2_m(arg0) {
+        wasm.__wbg_set_physicsparams_l2_m(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get g() {
+        const ret = wasm.__wbg_get_physicsparams_g(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set g(arg0) {
+        wasm.__wbg_set_physicsparams_g(this.__wbg_ptr, arg0);
+    }
+}
+
+const PhysicsStateFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_physicsstate_free(ptr >>> 0, 1));
+
+export class PhysicsState {
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        PhysicsStateFinalization.unregister(this);
+        return ptr;
     }
 
-    const PhysicsParamsFinalization = (typeof FinalizationRegistry === 'undefined')
-        ? { register: () => {}, unregister: () => {} }
-        : new FinalizationRegistry(ptr => wasm.__wbg_physicsparams_free(ptr >>> 0, 1));
-
-    class PhysicsParams {
-
-        __destroy_into_raw() {
-            const ptr = this.__wbg_ptr;
-            this.__wbg_ptr = 0;
-            PhysicsParamsFinalization.unregister(this);
-            return ptr;
-        }
-
-        free() {
-            const ptr = this.__destroy_into_raw();
-            wasm.__wbg_physicsparams_free(ptr, 0);
-        }
-        /**
-         * @returns {number}
-         */
-        get cart_m() {
-            const ret = wasm.__wbg_get_physicsparams_cart_m(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set cart_m(arg0) {
-            wasm.__wbg_set_physicsparams_cart_m(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get m1() {
-            const ret = wasm.__wbg_get_physicsparams_m1(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set m1(arg0) {
-            wasm.__wbg_set_physicsparams_m1(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get m2() {
-            const ret = wasm.__wbg_get_physicsparams_m2(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set m2(arg0) {
-            wasm.__wbg_set_physicsparams_m2(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get l1_m() {
-            const ret = wasm.__wbg_get_physicsparams_l1_m(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set l1_m(arg0) {
-            wasm.__wbg_set_physicsparams_l1_m(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get l2_m() {
-            const ret = wasm.__wbg_get_physicsparams_l2_m(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set l2_m(arg0) {
-            wasm.__wbg_set_physicsparams_l2_m(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get g() {
-            const ret = wasm.__wbg_get_physicsparams_g(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set g(arg0) {
-            wasm.__wbg_set_physicsparams_g(this.__wbg_ptr, arg0);
-        }
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_physicsstate_free(ptr, 0);
     }
-    __exports.PhysicsParams = PhysicsParams;
-
-    const PhysicsStateFinalization = (typeof FinalizationRegistry === 'undefined')
-        ? { register: () => {}, unregister: () => {} }
-        : new FinalizationRegistry(ptr => wasm.__wbg_physicsstate_free(ptr >>> 0, 1));
-
-    class PhysicsState {
-
-        __destroy_into_raw() {
-            const ptr = this.__wbg_ptr;
-            this.__wbg_ptr = 0;
-            PhysicsStateFinalization.unregister(this);
-            return ptr;
-        }
-
-        free() {
-            const ptr = this.__destroy_into_raw();
-            wasm.__wbg_physicsstate_free(ptr, 0);
-        }
-        /**
-         * @returns {number}
-         */
-        get a1() {
-            const ret = wasm.__wbg_get_physicsparams_cart_m(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set a1(arg0) {
-            wasm.__wbg_set_physicsparams_cart_m(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get a2() {
-            const ret = wasm.__wbg_get_physicsparams_m1(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set a2(arg0) {
-            wasm.__wbg_set_physicsparams_m1(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get a1_v() {
-            const ret = wasm.__wbg_get_physicsparams_m2(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set a1_v(arg0) {
-            wasm.__wbg_set_physicsparams_m2(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get a2_v() {
-            const ret = wasm.__wbg_get_physicsparams_l1_m(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set a2_v(arg0) {
-            wasm.__wbg_set_physicsparams_l1_m(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get cart_x_m() {
-            const ret = wasm.__wbg_get_physicsparams_l2_m(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set cart_x_m(arg0) {
-            wasm.__wbg_set_physicsparams_l2_m(this.__wbg_ptr, arg0);
-        }
-        /**
-         * @returns {number}
-         */
-        get cart_x_v_m() {
-            const ret = wasm.__wbg_get_physicsparams_g(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} arg0
-         */
-        set cart_x_v_m(arg0) {
-            wasm.__wbg_set_physicsparams_g(this.__wbg_ptr, arg0);
-        }
+    /**
+     * @returns {number}
+     */
+    get a1() {
+        const ret = wasm.__wbg_get_physicsparams_cart_m(this.__wbg_ptr);
+        return ret;
     }
-    __exports.PhysicsState = PhysicsState;
-
-    const WasmPendulumPhysicsFinalization = (typeof FinalizationRegistry === 'undefined')
-        ? { register: () => {}, unregister: () => {} }
-        : new FinalizationRegistry(ptr => wasm.__wbg_wasmpendulumphysics_free(ptr >>> 0, 1));
-
-    class WasmPendulumPhysics {
-
-        __destroy_into_raw() {
-            const ptr = this.__wbg_ptr;
-            this.__wbg_ptr = 0;
-            WasmPendulumPhysicsFinalization.unregister(this);
-            return ptr;
-        }
-
-        free() {
-            const ptr = this.__destroy_into_raw();
-            wasm.__wbg_wasmpendulumphysics_free(ptr, 0);
-        }
-        /**
-         * @param {number} cart_m
-         * @param {number} m1
-         * @param {number} m2
-         * @param {number} l1_m
-         * @param {number} l2_m
-         * @param {number} g
-         */
-        constructor(cart_m, m1, m2, l1_m, l2_m, g) {
-            const ret = wasm.wasmpendulumphysics_new(cart_m, m1, m2, l1_m, l2_m, g);
-            this.__wbg_ptr = ret >>> 0;
-            WasmPendulumPhysicsFinalization.register(this, this.__wbg_ptr, this);
-            return this;
-        }
-        reset() {
-            wasm.wasmpendulumphysics_reset(this.__wbg_ptr);
-        }
-        /**
-         * @returns {any}
-         */
-        get_state_js() {
-            const ret = wasm.wasmpendulumphysics_get_state_js(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @returns {any}
-         */
-        get_params_js() {
-            const ret = wasm.wasmpendulumphysics_get_params_js(this.__wbg_ptr);
-            return ret;
-        }
-        /**
-         * @param {number} dt
-         * @param {number} force_override
-         * @param {boolean} simulation_mode_is_observing
-         * @returns {boolean}
-         */
-        update_physics_step(dt, force_override, simulation_mode_is_observing) {
-            const ret = wasm.wasmpendulumphysics_update_physics_step(this.__wbg_ptr, dt, force_override, simulation_mode_is_observing);
-            return ret !== 0;
-        }
+    /**
+     * @param {number} arg0
+     */
+    set a1(arg0) {
+        wasm.__wbg_set_physicsparams_cart_m(this.__wbg_ptr, arg0);
     }
-    __exports.WasmPendulumPhysics = WasmPendulumPhysics;
+    /**
+     * @returns {number}
+     */
+    get a2() {
+        const ret = wasm.__wbg_get_physicsparams_m1(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set a2(arg0) {
+        wasm.__wbg_set_physicsparams_m1(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get a1_v() {
+        const ret = wasm.__wbg_get_physicsparams_m2(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set a1_v(arg0) {
+        wasm.__wbg_set_physicsparams_m2(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get a2_v() {
+        const ret = wasm.__wbg_get_physicsparams_l1_m(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set a2_v(arg0) {
+        wasm.__wbg_set_physicsparams_l1_m(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get cart_x_m() {
+        const ret = wasm.__wbg_get_physicsparams_l2_m(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set cart_x_m(arg0) {
+        wasm.__wbg_set_physicsparams_l2_m(this.__wbg_ptr, arg0);
+    }
+    /**
+     * @returns {number}
+     */
+    get cart_x_v_m() {
+        const ret = wasm.__wbg_get_physicsparams_g(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} arg0
+     */
+    set cart_x_v_m(arg0) {
+        wasm.__wbg_set_physicsparams_g(this.__wbg_ptr, arg0);
+    }
+}
 
-    async function __wbg_load(module, imports) {
-        if (typeof Response === 'function' && module instanceof Response) {
-            if (typeof WebAssembly.instantiateStreaming === 'function') {
-                try {
-                    return await WebAssembly.instantiateStreaming(module, imports);
+const WasmPendulumPhysicsFinalization = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(ptr => wasm.__wbg_wasmpendulumphysics_free(ptr >>> 0, 1));
 
-                } catch (e) {
-                    if (module.headers.get('Content-Type') != 'application/wasm') {
-                        console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+export class WasmPendulumPhysics {
 
-                    } else {
-                        throw e;
-                    }
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+        WasmPendulumPhysicsFinalization.unregister(this);
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_wasmpendulumphysics_free(ptr, 0);
+    }
+    /**
+     * @param {number} cart_m
+     * @param {number} m1
+     * @param {number} m2
+     * @param {number} l1_m
+     * @param {number} l2_m
+     * @param {number} g
+     */
+    constructor(cart_m, m1, m2, l1_m, l2_m, g) {
+        const ret = wasm.wasmpendulumphysics_new(cart_m, m1, m2, l1_m, l2_m, g);
+        this.__wbg_ptr = ret >>> 0;
+        WasmPendulumPhysicsFinalization.register(this, this.__wbg_ptr, this);
+        return this;
+    }
+    reset() {
+        wasm.wasmpendulumphysics_reset(this.__wbg_ptr);
+    }
+    /**
+     * @returns {any}
+     */
+    get_state_js() {
+        const ret = wasm.wasmpendulumphysics_get_state_js(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @returns {any}
+     */
+    get_params_js() {
+        const ret = wasm.wasmpendulumphysics_get_params_js(this.__wbg_ptr);
+        return ret;
+    }
+    /**
+     * @param {number} dt
+     * @param {number} force_override
+     * @param {boolean} simulation_mode_is_observing
+     * @returns {boolean}
+     */
+    update_physics_step(dt, force_override, simulation_mode_is_observing) {
+        const ret = wasm.wasmpendulumphysics_update_physics_step(this.__wbg_ptr, dt, force_override, simulation_mode_is_observing);
+        return ret !== 0;
+    }
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+
+            } catch (e) {
+                if (module.headers.get('Content-Type') != 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else {
+                    throw e;
                 }
             }
+        }
 
-            const bytes = await module.arrayBuffer();
-            return await WebAssembly.instantiate(bytes, imports);
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
 
         } else {
-            const instance = await WebAssembly.instantiate(module, imports);
+            return instance;
+        }
+    }
+}
 
-            if (instance instanceof WebAssembly.Instance) {
-                return { instance, module };
+function __wbg_get_imports() {
+    const imports = {};
+    imports.wbg = {};
+    imports.wbg.__wbg_new_405e22f390576ce2 = function() {
+        const ret = new Object();
+        return ret;
+    };
+    imports.wbg.__wbg_set_3f1d0b984ed272ed = function(arg0, arg1, arg2) {
+        arg0[arg1] = arg2;
+    };
+    imports.wbg.__wbg_warn_bd702e7811e10e4e = function(arg0, arg1) {
+        console.warn(getStringFromWasm0(arg0, arg1));
+    };
+    imports.wbg.__wbindgen_init_externref_table = function() {
+        const table = wasm.__wbindgen_export_0;
+        const offset = table.grow(4);
+        table.set(0, undefined);
+        table.set(offset + 0, undefined);
+        table.set(offset + 1, null);
+        table.set(offset + 2, true);
+        table.set(offset + 3, false);
+        ;
+    };
+    imports.wbg.__wbindgen_number_new = function(arg0) {
+        const ret = arg0;
+        return ret;
+    };
+    imports.wbg.__wbindgen_string_new = function(arg0, arg1) {
+        const ret = getStringFromWasm0(arg0, arg1);
+        return ret;
+    };
+    imports.wbg.__wbindgen_throw = function(arg0, arg1) {
+        throw new Error(getStringFromWasm0(arg0, arg1));
+    };
 
-            } else {
-                return instance;
-            }
+    return imports;
+}
+
+function __wbg_init_memory(imports, memory) {
+
+}
+
+function __wbg_finalize_init(instance, module) {
+    wasm = instance.exports;
+    __wbg_init.__wbindgen_wasm_module = module;
+    cachedUint8ArrayMemory0 = null;
+
+
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module !== 'undefined') {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
         }
     }
 
-    function __wbg_get_imports() {
-        const imports = {};
-        imports.wbg = {};
-        imports.wbg.__wbg_new_405e22f390576ce2 = function() {
-            const ret = new Object();
-            return ret;
-        };
-        imports.wbg.__wbg_random_3ad904d98382defe = function() {
-            const ret = Math.random();
-            return ret;
-        };
-        imports.wbg.__wbg_set_3f1d0b984ed272ed = function(arg0, arg1, arg2) {
-            arg0[arg1] = arg2;
-        };
-        imports.wbg.__wbg_warn_bd702e7811e10e4e = function(arg0, arg1) {
-            console.warn(getStringFromWasm0(arg0, arg1));
-        };
-        imports.wbg.__wbindgen_init_externref_table = function() {
-            const table = wasm.__wbindgen_export_0;
-            const offset = table.grow(4);
-            table.set(0, undefined);
-            table.set(offset + 0, undefined);
-            table.set(offset + 1, null);
-            table.set(offset + 2, true);
-            table.set(offset + 3, false);
-            ;
-        };
-        imports.wbg.__wbindgen_number_new = function(arg0) {
-            const ret = arg0;
-            return ret;
-        };
-        imports.wbg.__wbindgen_string_new = function(arg0, arg1) {
-            const ret = getStringFromWasm0(arg0, arg1);
-            return ret;
-        };
-        imports.wbg.__wbindgen_throw = function(arg0, arg1) {
-            throw new Error(getStringFromWasm0(arg0, arg1));
-        };
+    const imports = __wbg_get_imports();
 
-        return imports;
+    __wbg_init_memory(imports);
+
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
     }
 
-    function __wbg_init_memory(imports, memory) {
+    const instance = new WebAssembly.Instance(module, imports);
 
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (typeof module_or_path !== 'undefined') {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
     }
 
-    function __wbg_finalize_init(instance, module) {
-        wasm = instance.exports;
-        __wbg_init.__wbindgen_wasm_module = module;
-        cachedUint8ArrayMemory0 = null;
+    if (typeof module_or_path === 'undefined') {
+        module_or_path = new URL('physics_engine_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
 
-
-        wasm.__wbindgen_start();
-        return wasm;
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
     }
 
-    function initSync(module) {
-        if (wasm !== undefined) return wasm;
+    __wbg_init_memory(imports);
 
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
 
-        if (typeof module !== 'undefined') {
-            if (Object.getPrototypeOf(module) === Object.prototype) {
-                ({module} = module)
-            } else {
-                console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
-            }
-        }
+    return __wbg_finalize_init(instance, module);
+}
 
-        const imports = __wbg_get_imports();
-
-        __wbg_init_memory(imports);
-
-        if (!(module instanceof WebAssembly.Module)) {
-            module = new WebAssembly.Module(module);
-        }
-
-        const instance = new WebAssembly.Instance(module, imports);
-
-        return __wbg_finalize_init(instance, module);
-    }
-
-    async function __wbg_init(module_or_path) {
-        if (wasm !== undefined) return wasm;
-
-
-        if (typeof module_or_path !== 'undefined') {
-            if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
-                ({module_or_path} = module_or_path)
-            } else {
-                console.warn('using deprecated parameters for the initialization function; pass a single object instead')
-            }
-        }
-
-        if (typeof module_or_path === 'undefined' && typeof script_src !== 'undefined') {
-            module_or_path = script_src.replace(/\.js$/, '_bg.wasm');
-        }
-        const imports = __wbg_get_imports();
-
-        if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
-            module_or_path = fetch(module_or_path);
-        }
-
-        __wbg_init_memory(imports);
-
-        const { instance, module } = await __wbg_load(await module_or_path, imports);
-
-        return __wbg_finalize_init(instance, module);
-    }
-
-    wasm_bindgen = Object.assign(__wbg_init, { initSync }, __exports);
-
-})();
+export { initSync };
+export default __wbg_init;


### PR DESCRIPTION
## Summary
- regenerate JS and TypeScript bindings for the physics engine
- revert the `physics_engine_bg.wasm` binary so no binary changes remain
- confirm that the physics update already uses a 4th‑order RK4 integrator

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6854f18c1a58832fa248b93dd1353a8c