### PR TITLE
Fix TensorFlow.js import in worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,7 +1,10 @@
 // This script runs in a separate thread.
-// Import TensorFlow.js library and WASM backend as ES modules
-import * as tf from 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@latest/dist/tf.min.js';
-import 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@latest/dist/tf-backend-wasm.js';
+// Import TensorFlow.js using an ES module bundle from Skypack so that
+// functions like `setBackend` and the Layers API are available in this
+// module worker environment.
+import * as tf from 'https://cdn.skypack.dev/@tensorflow/tfjs';
+// Load the WebAssembly backend for TensorFlow.js
+import 'https://cdn.skypack.dev/@tensorflow/tfjs-backend-wasm';
 // Import the JS glue code for your Wasm physics module
 import initWasm, { WasmPendulumPhysics } from './pkg_physics/physics_engine.js';
 


### PR DESCRIPTION
## Summary
- use Skypack ESM bundle for TensorFlow.js so `tf.setBackend` and layers API work in the module worker

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68550dcf2bb4832fb09d9d64ff2f04fe