### PR TITLE
Fix worker initialization for classic script

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,7 +74,10 @@ class PendulumRenderer {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const worker = new Worker('worker.js', { type: 'module' });
+    const worker = new Worker('worker.js');
+    worker.addEventListener('error', (e) => {
+        console.error('Worker error:', e.message);
+    });
     
     const renderer = new PendulumRenderer();
     // Main control buttons - pauseResumeButton will be repurposed


### PR DESCRIPTION
## Summary
- start the worker as a classic script
- dynamically import the Wasm physics module and handle load errors
- forward worker errors to the main thread

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685518e4be14832fb424412a9674f7d5